### PR TITLE
Trying to integrate Terraform to deploy in AWS instead of Vagrant deploying locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+terraform.tfvars
+.terraform
 *.swp
 *.swo
 *~

--- a/ansible/ansible-playbook_wrapper
+++ b/ansible/ansible-playbook_wrapper
@@ -1,0 +1,13 @@
+#!/bin/bash
+SCRIPTPATH=`dirname $0`
+export ANSIBLE_HOSTS="$SCRIPTPATH/production/inventory"
+export ANSIBLE_CONFIG=$SCRIPTPATH/ansible.cfg
+if [ -s $SCRIPTPATH/config_ssh ]
+then
+   export ANSIBLE_SSH_ARGS="-F config_ssh -o ControlMaster=auto -o ControlPersist=30m"
+fi
+if [ -s $SCRIPTPATH/.ansible_vault_pass ]
+then
+   export ANSIBLE_VAULT_PASSWORD_FILE=$SCRIPTPATH/.ansible_vault_pass
+fi
+ansible-playbook "$@"

--- a/ansible/ansible-vault_wrapper
+++ b/ansible/ansible-vault_wrapper
@@ -1,0 +1,8 @@
+#!/bin/bash
+SCRIPTPATH=`dirname $0`
+export ANSIBLE_CONFIG=$SCRIPTPATH/ansible.cfg
+if [ -s $SCRIPTPATH/.ansible_vault_pass ]
+then
+   export ANSIBLE_VAULT_PASSWORD_FILE=$SCRIPTPATH/.ansible_vault_pass
+fi
+ansible-vault "$@"

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,44 @@
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# nearly all parameters can be overridden in ansible-playbook
+# or with command line flags. ansible will read ANSIBLE_CONFIG,
+# ansible.cfg in the current working directory, .ansible.cfg in
+# the home directory or /etc/ansible/ansible.cfg, whichever it
+# finds first
+
+[defaults]
+# SSH timeout
+timeout = 30
+host_key_checking = False
+roles_path = roles
+
+[ssh_connection]
+
+# ssh arguments to use
+# Leaving off ControlPersist will result in poor performance, so use
+# paramiko on older platforms rather than removing it
+ssh_args = -o ControlMaster=auto -o ControlPersist=30m
+
+# Enabling pipelining reduces the number of SSH operations required to
+# execute a module on the remote server. This can result in a significant
+# performance improvement when enabled, however when using "sudo:" you must
+# first disable 'requiretty' in /etc/sudoers
+#
+# By default, this option is disabled to preserve compatibility with
+# sudoers configurations that have requiretty (the default on many distros).
+#
+pipelining = True
+
+# if True, make ansible use scp if the connection type is ssh
+# (default is sftp)
+scp_if_ssh = True
+
+[accelerate]
+accelerate_port = 5099
+accelerate_timeout = 30
+accelerate_connect_timeout = 5.0
+
+# The daemon timeout is measured in minutes. This time is measured
+# from the last activity to the accelerate daemon.
+accelerate_daemon_timeout = 30

--- a/ansible/ansible_wrapper
+++ b/ansible/ansible_wrapper
@@ -1,0 +1,15 @@
+#!/bin/bash -x
+SCRIPTPATH=`dirname $0`
+export ANSIBLE_HOSTS="$SCRIPTPATH/production/inventory"
+export ANSIBLE_CONFIG=$SCRIPTPATH/ansible.cfg
+if [ -s $SCRIPTPATH/config_ssh ]
+then
+   export ANSIBLE_SSH_ARGS="-F config_ssh -o ControlMaster=auto -o ControlPersist=30m"
+fi
+if [ -s $SCRIPTPATH/.ansible_vault_pass ]
+then
+   export ANSIBLE_VAULT_PASSWORD_FILE=$SCRIPTPATH/.ansible_vault_pass
+fi
+MY_ANSIBLE_HOST_PATTERN="$1"
+shift
+ansible "$MY_ANSIBLE_HOST_PATTERN" -i $ANSIBLE_HOSTS "$@"

--- a/ansible/config_ssh.template
+++ b/ansible/config_ssh.template
@@ -1,0 +1,32 @@
+
+##
+## Simple use case
+##
+
+Host *
+  User USER
+  IdentityFile PATH_TO_YOUR_PRIVATE_KEY
+
+##
+## Bastion use case
+##
+
+# this is a template file to configure ssh to do transparent proxy on a bastion host
+# to use it :
+#  > cp config_ssh.template config_ssh
+#  configure USER and IdentityFile lines
+# save and enjoy transparent proxy by using ssh_wrapper :)
+
+
+#Host bastion_host
+#  User USER
+#  Port 2222
+#  HostName bastion_hostname_or_ip
+#  IdentityFile PATH_TO_YOUR_PRIVATE_KEY
+#  ForwardAgent yes
+#  ProxyCommand none
+#  BatchMode yes
+#
+#Host *
+#  User USER
+#  ProxyCommand ssh -F config_ssh -W %h:%p bastion_host

--- a/ansible/configure_host.yml
+++ b/ansible/configure_host.yml
@@ -1,0 +1,21 @@
+---
+#first time ./ansible-playbook_wrapper configure_host.yml -u yourgenericaccount -Kk  -e "NAME_PROJECT=myproject"
+#second time ./ansible-playbook_wrapper configure_host.yml -K  -e "NAME_PROJECT=myproject"
+
+- hosts: "{{ NAME_PROJECT }}"
+  gather_facts: false
+  tasks:
+  - name: Make sure python is installed
+    raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
+    become: true
+
+- hosts: "{{ NAME_PROJECT }}"
+  roles:
+  - {role: "AdopteUnOps.install-kernel", tags: "kernel"}
+  - {role: "AdopteUnOps.configure-rsyslog", tags: "rsyslog"}
+  - {role: "AdopteUnOps.configure-hostname", tags: "configure-hostname"}
+  - {role: "AdopteUnOps.configure-ssh", tags: "configure-ssh"}
+  - {role: "AdopteUnOps.install-debugging-tools", tags: "install-tools"}
+  - {role: "AdopteUnOps.docker", tags: "install-docker"}
+  - {role: "AdopteUnOps.upgrade-packages", tags: "upgrade-packages"}
+  - {role: "AdopteUnOps.configure-unix-accounts", tags: "ops"}

--- a/ansible/create_master.yml
+++ b/ansible/create_master.yml
@@ -1,0 +1,7 @@
+---
+#./ansible-playbook_wrapper create_master.yml -K
+- hosts: rancher-master
+  roles:
+  - {role: AdopteUnOps.mysql-docker, tags: mysql}
+  - {role: AdopteUnOps.rancher-install-master, tags: rancher-master}
+  - {role: AdopteUnOps.rancher-configure-catalog, tags: catalogs}

--- a/ansible/create_project.yml
+++ b/ansible/create_project.yml
@@ -1,0 +1,18 @@
+---
+#./ansible-playbook_wrapper create_project.yml -K -e "NAME_PROJECT=myproject"
+- hosts: "{{ NAME_PROJECT}}[0]"
+  gather_facts: no
+  roles:
+  - {role: AdopteUnOps.rancher-create-project, tags: rancher-create-project}
+
+- hosts: "{{ NAME_PROJECT }}"
+  pre_tasks:
+  # force reload of apikey, as it's cached by ansible when we first trigger the playbook
+  - include_vars: "{{ inventory_dir }}/group_vars/{{ NAME_PROJECT }}/apikey.yml"
+  roles:
+  - {role: AdopteUnOps.rancher-add-host, tags: add-host}
+
+- hosts: "{{ NAME_PROJECT}}[0]"
+  gather_facts: no
+  roles:
+  - {role: AdopteUnOps.rancher-install-stack, stack_name: janitor, tags: install-stack}

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,21 @@
+#configure host dependencies
+- src: AdopteUnOps.install-kernel
+- src: AdopteUnOps.configure-rsyslog
+- src: AdopteUnOps.configure-hostname
+- src: AdopteUnOps.configure-ssh
+- src: AdopteUnOps.install-debugging-tools
+- src: AdopteUnOps.docker
+- src: AdopteUnOps.upgrade-packages
+- src: AdopteUnOps.configure-unix-accounts
+
+# rancher stuff dependencies
+- src: AdopteUnOps.mysql-docker
+- src: AdopteUnOps.rancher-install-master
+- src: AdopteUnOps.rancher-create-project
+- src: AdopteUnOps.rancher-add-host
+- src: AdopteUnOps.rancher-install-stack
+- src: AdopteUnOps.rancher-configure-catalog
+- src: AdopteUnOps.clean-docker-host
+- src: AdopteUnOps.rancher-delete-host
+- src: AdopteUnOps.rancher-delete-project
+ 

--- a/ansible/sample/group_vars/all/rancher
+++ b/ansible/sample/group_vars/all/rancher
@@ -1,0 +1,18 @@
+DEVOPS_LOGIN: devops
+DEVOPS_PASSWORD: changeme
+rancher_master_host: "{{groups['rancher-master'][0]}}"
+rancher_master_port: 8080
+rancher_version: v1.6.10
+rancher_agent_version: v1.2.6
+
+rancher_catalogs:
+  catalogs:
+    library:
+      url: https://git.rancher.io/rancher-catalog.git
+      branch: "${RELEASE}"
+    community:
+      url: https://git.rancher.io/community-catalog.git
+      branch: master
+    adopteunops-catalog:
+      url: https://github.com/AdopteUnOps/rancher-catalog.git
+      branch: master

--- a/ansible/sample/group_vars/all/unix_accounts
+++ b/ansible/sample/group_vars/all/unix_accounts
@@ -1,0 +1,6 @@
+ssh_users:
+    - name: myuser
+      key: "ssh-rsa ZZZZZYOURSSHKEY"
+      password: "changeme"
+former_ops_users:
+    - name: mygenericaccount

--- a/ansible/sample/group_vars/all/vars
+++ b/ansible/sample/group_vars/all/vars
@@ -1,0 +1,1 @@
+normalized_project_name: "{{ NAME_PROJECT | lower}}"

--- a/ansible/sample/group_vars/rancher-master/mysql-rancher
+++ b/ansible/sample/group_vars/rancher-master/mysql-rancher
@@ -1,0 +1,13 @@
+mysql_host: "{{ groups.mysql[0] }}"
+mysql_database: rancher
+mysql_user: rancher
+mysql_password: pha8Queirierane
+
+mysql_backup_enabled: false
+
+mysql_s3_access_key: A_S3_TOKEN
+mysql_s3_secret_key: S3_SECRET
+mysql_s3_bucket: rancher-s3
+mysql_s3_prefix: rancher-master-backup
+mysql_s3_region: eu-central-1
+mysql_s3_schedule: "@daily"

--- a/ansible/sample/inventory
+++ b/ansible/sample/inventory
@@ -1,0 +1,6 @@
+[rancher-master]
+host-1
+
+[my-first-project]
+host-3
+host-4

--- a/ansible/scp_wrapper
+++ b/ansible/scp_wrapper
@@ -1,0 +1,12 @@
+#!/bin/bash
+SCRIPTPATH=`dirname $0`
+sshconfig_file=${SCRIPTPATH}/config_ssh
+if [ ! -d ${HOME}/.ansible/cp ]; then
+	mkdir -p ${HOME}/.ansible/cp
+fi
+if [ -f ${sshconfig_file} ]; then
+scp -F ${sshconfig_file}  -o ControlMaster=auto -o ControlPersist=30m -o ControlPath="${HOME}/.ansible/cp/ansible-ssh-%h-%p-%r" "$@"
+else
+scp -o ControlMaster=auto -o ControlPersist=30m -o ControlPath="${HOME}/.ansible/cp/ansible-ssh-%h-%p-%r" "$@"
+fi
+

--- a/ansible/ssh_wrapper
+++ b/ansible/ssh_wrapper
@@ -1,0 +1,12 @@
+#!/bin/bash
+SCRIPTPATH=`dirname $0`
+sshconfig_file=${SCRIPTPATH}/config_ssh
+if [ ! -d ${HOME}/.ansible/cp ]; then
+	mkdir -p ${HOME}/.ansible/cp
+fi
+if [ -f ${sshconfig_file} ]; then
+ssh -F ${sshconfig_file}  -o ControlMaster=auto -o ControlPersist=30m -o ControlPath="${HOME}/.ansible/cp/ansible-ssh-%h-%p-%r" "$@"
+else
+ssh -o ControlMaster=auto -o ControlPersist=30m -o ControlPath="${HOME}/.ansible/cp/ansible-ssh-%h-%p-%r" "$@"
+fi
+

--- a/ansible/templates/janitor/docker-compose.yml
+++ b/ansible/templates/janitor/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '2'
+services:
+  cleanup:
+    privileged: true
+    image: meltwater/docker-cleanup:1.8.0
+    environment:
+      CLEAN_PERIOD: '3600'
+      DEBUG: '0'
+      DELAY_TIME: '900'
+      KEEP_CONTAINERS: '*:*'
+      KEEP_CONTAINERS_NAMED: '*-datavolume'
+      KEEP_IMAGES: rancher/
+      LOOP: 'true'
+    network_mode: none
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /var/lib/docker:/var/lib/docker
+    labels:
+      io.rancher.scheduler.affinity:host_label_ne: janitor.exclude=true
+      io.rancher.scheduler.global: 'true'

--- a/ansible/templates/janitor/rancher-compose.yml
+++ b/ansible/templates/janitor/rancher-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  cleanup:
+    start_on_create: true

--- a/ansible/utils_clean_host.yml
+++ b/ansible/utils_clean_host.yml
@@ -1,0 +1,15 @@
+---
+# clean One HOST on project
+#./ansible-playbook_wrapper utils_clean_host.yml -K -e "NAME_PROJECT=myproject" -e "NAME_HOST=myHost" (check with inventory)
+# If you want delete all host of the project, you can't set NAME_HOST
+- hosts: rancher-masters
+  gather_facts: no
+  roles:
+  - AdopteUnOps.rancher-delete-host
+
+- vars:
+    NAME_HOST: "{{ NAME_PROJECT }}"
+  hosts: "{{ NAME_HOST }}"
+  gather_facts: no
+  roles:
+  - AdopteUnOps.rancher-clean-docker-host

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,8 @@
+#------------------------------------------#
+# AWS Provider Configuration
+#------------------------------------------#
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region 	 = "${var.region}"
+}

--- a/create-inv.tf
+++ b/create-inv.tf
@@ -1,0 +1,19 @@
+resource "null_resource" "ansible-provision" {
+  depends_on = ["aws_instance.rancher_ha", "aws_instance.rancher_host_dev"]
+ 
+  provisioner "local-exec" {
+    command = "echo \"[rancher_ha]\" &gt; rancher-inventory"
+  }
+ 
+  provisioner "local-exec" {
+    command = "echo \"${join("\n",formatlist("%s ansible_ssh_user=%s", aws_instance.rancher_ha.*.public_ip, var.ssh_user))}\" &gt;&gt; rancher-inventory"
+  }
+ 
+  provisioner "local-exec" {
+    command = "echo \"[rancher-nodes]\" &gt;&gt; rancher-inventory"
+  }
+ 
+  provisioner "local-exec" {
+    command = "echo \"${join("\n",formatlist("%s ansible_ssh_user=%s", aws_instance.rancher_host_dev.*.public_ip, var.ssh_user))}\" &gt;&gt; rancher-inventory"
+  }
+} 

--- a/ec2-rancher-host.tf
+++ b/ec2-rancher-host.tf
@@ -1,0 +1,75 @@
+#------------------------------------------#
+# AWS EC2 Configuration
+#------------------------------------------#
+resource "aws_instance" "rancher_host_dev" {
+    count                       = "${var.count_host_dev_env}"
+    ami                         = "${var.ami}"
+    instance_type               = "${var.instance_type}"
+    key_name                    = "${var.key_name}"
+    subnet_id                   = "${element(sort(aws_subnet.rancher_ha.*.id), count.index)}"
+
+    vpc_security_group_ids = ["${aws_security_group.rancher_ha.id}"]
+
+    tags {
+        Name = "${var.name_prefix_host_dev}-${count.index}"
+    }
+
+    root_block_device {
+        volume_size = "${var.root_volume_size}"
+        delete_on_termination = true
+    }
+    depends_on = ["aws_security_group.rancher_ha"]
+    
+    provisioner "remote-exec" {
+        inline = ["# Connected!"]
+        connection {
+            user = "${var.ssh_user}"
+	    private_key = "${file(var.private_key_path)}"
+	    }
+    }
+
+    provisioner "local-exec" {
+        command = "./ansible/ansible-playbook ./create_project.yml --extra-vars 'rancher_master_host = ${element(sort(aws_instance.rancher_ha.*.private_ip), count.index)} rancher_master_port = 8080 rancher_master_url = http://{{rancher_master_host}}:{{rancher_master_port}} rancher_project_name = dev'"
+    }
+
+}
+resource "aws_security_group" "rancher_host" {
+    name        = "${var.name_prefix}-host"
+    description = "Rancher HA Host Ports"
+    vpc_id      = "${aws_vpc.rancher_ha.id}"
+
+    ingress {
+        from_port = 0
+        to_port   = 65535
+        protocol  = "tcp"
+        self      = true
+    }
+
+    ingress {
+        from_port = 0
+        to_port   = 65535
+        protocol  = "udp"
+        self      = true
+    }
+
+    ingress {
+        from_port   = 8080
+        to_port     = 8080
+        protocol    = "tcp"
+        cidr_blocks = ["${var.vpc_cidr}"]
+    }
+
+    ingress {
+        from_port   = 9345
+        to_port     = 9345
+        protocol    = "tcp"
+        cidr_blocks = ["${var.vpc_cidr}"]
+    }
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}

--- a/ec2-rancher-srv.tf
+++ b/ec2-rancher-srv.tf
@@ -1,0 +1,104 @@
+#------------------------------------------#
+# AWS EC2 Configuration
+#------------------------------------------#
+resource "aws_instance" "rancher_ha" {
+    count                       = "${var.count_srv}"
+    ami                         = "${var.ami}"
+    instance_type               = "${var.instance_type}"
+    key_name                    = "${var.key_name}"
+    subnet_id                   = "${element(sort(aws_subnet.rancher_ha.*.id), count.index)}"
+
+    vpc_security_group_ids = ["${aws_security_group.rancher_ha.id}"]
+
+    tags {
+        Name = "${var.name_prefix}-${count.index}"
+    }
+
+    root_block_device {
+        volume_size = "${var.root_volume_size}"
+        delete_on_termination = true
+    }
+    depends_on = ["aws_security_group.rancher_ha"]
+
+    provisioner "remote-exec" {
+        inline = ["# Connected!"]
+        connection {
+            user = "${var.ssh_user}"
+	    private_key = "${file(var.private_key_path)}"
+	    }
+    }
+
+    provisioner "local-exec" {
+        command = "./ansible/ansible-playbook ./create_master.yml -u ${var.ssh_user} --extra-vars 'mysql_host = ${self.private_ip} mysql_database = ${var.db_name} mysql_user = ${var.db_user} mysql_password = ${var.db_pass} rancher_master_host = ${self.private_ip} rancher_master_port = 8080'"
+    }
+    
+##using ansible 
+#   provisioner "ansible" {
+#    connection {
+#        user = "${var.ssh_user}"
+#    }
+#    playbook = "ansible/create_master.yml"
+#    hosts = ["rancher-master"]
+#    plays = ["rancher-master"]
+#    groups = ["rancher-master"]
+#    extra_vars = { 
+#	  "mysql_host" = "${self.private_ip}",
+#         "mysql_database" = "${var.db_name}",
+#         "mysql_user" = "${var.db_user}",
+#         "mysql_password" = "${var.db_pass}",
+#         #"rancher_master_host" = "${element(sort(aws_instance.rancher_ha.*.private_ip), count.index)}",
+#	  "rancher_master_host" = "${self.private_ip}",	
+#         "rancher_master_port" = "8080",
+#	}
+#}
+
+}
+
+resource "aws_security_group" "rancher_ha" {
+    name        = "${var.name_prefix}-server"
+    description = "Rancher HA Server Ports"
+    vpc_id      = "${aws_vpc.rancher_ha.id}"
+
+    ingress {
+        from_port = 0
+        to_port   = 65535
+        protocol  = "tcp"
+        self      = true
+    }
+
+    ingress {
+        from_port = 0
+        to_port   = 65535
+        protocol  = "udp"
+        self      = true
+    }
+
+    ingress {
+        from_port   = 8080
+        to_port     = 8080
+        protocol    = "tcp"
+        cidr_blocks = ["${var.vpc_cidr}"]
+    }
+
+    ingress {
+        from_port   = 9345
+        to_port     = 9345
+        protocol    = "tcp"
+        cidr_blocks = ["${var.vpc_cidr}"]
+    }
+
+    ingress {
+        from_port   = 22
+        to_port     = 22
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}

--- a/elb_common.tf
+++ b/elb_common.tf
@@ -1,0 +1,35 @@
+#------------------------------------------#
+# Elastic Load Balancer Common Configuration
+#------------------------------------------#
+resource "aws_security_group" "rancher_ha_elb" {
+    name        = "${var.name_prefix}-elb-default"
+    description = "Rancher HA ELB Common Traffic"
+    vpc_id      = "${aws_vpc.rancher_ha.id}"
+}
+
+resource "aws_security_group_rule" "allow_all_self" {
+    type              = "ingress"
+    from_port         = 0
+    to_port           = 0
+    protocol          = "-1"
+    self              = true
+    security_group_id = "${aws_security_group.rancher_ha_elb.id}"
+}
+
+resource "aws_security_group_rule" "allow_icmp" {
+    type              = "ingress"
+    from_port         = 0
+    to_port           = 0
+    protocol          = "icmp"
+    cidr_blocks       = ["0.0.0.0/0"]
+    security_group_id = "${aws_security_group.rancher_ha_elb.id}"
+}
+
+resource "aws_security_group_rule" "allow_all_out" {
+    type              = "egress"
+    from_port         = 0
+    to_port           = 0
+    protocol          = "-1"
+    cidr_blocks       = ["0.0.0.0/0"]
+    security_group_id = "${aws_security_group.rancher_ha_elb.id}"
+}

--- a/elb_http.tf
+++ b/elb_http.tf
@@ -1,0 +1,52 @@
+#------------------------------------------#
+# Elastic Load Balancer Configuration
+#------------------------------------------#
+resource "aws_elb" "rancher_ha_http" {
+    count    = "${1 - var.enable_https}"
+    name     = "${var.name_prefix}-elb-http"
+    internal = "${var.internal_elb}"
+
+    listener {
+        instance_port     = 8080
+        instance_protocol = "tcp"
+        lb_port           = 80
+        lb_protocol       = "tcp"
+    }
+
+    health_check {
+        healthy_threshold   = 2
+        unhealthy_threshold = 2
+        timeout             = 3
+        target              = "HTTP:8080/ping"
+        interval            = 30
+    }
+
+    subnets         = ["${aws_subnet.rancher_ha.*.id}"]
+    security_groups = ["${aws_security_group.rancher_ha_elb.id}"]
+    instances       = ["${aws_instance.rancher_ha.*.id}"]
+
+    idle_timeout                = 400
+    cross_zone_load_balancing   = true
+    connection_draining         = true
+    connection_draining_timeout = 400
+
+    tags {
+        Name = "${var.name_prefix}-elb-http"
+    }
+}
+
+resource "aws_proxy_protocol_policy" "rancher_ha_http_proxy_policy" {
+    count          = "${1 - var.enable_https}"
+    load_balancer  = "${aws_elb.rancher_ha_http.name}"
+    instance_ports = ["80", "81", "8080"]
+}
+
+resource "aws_security_group_rule" "allow_http" {
+    count             = "${1 - var.enable_https}"
+    type              = "ingress"
+    from_port         = 80
+    to_port           = 80
+    protocol          = "tcp"
+    cidr_blocks       = ["0.0.0.0/0"]
+    security_group_id = "${aws_security_group.rancher_ha_elb.id}"
+}

--- a/elb_https.tf
+++ b/elb_https.tf
@@ -1,0 +1,61 @@
+#------------------------------------------#
+# Elastic Load Balancer Configuration
+#------------------------------------------#
+resource "aws_elb" "rancher_ha_https" {
+    count    = "${var.enable_https}"
+    name     = "${var.name_prefix}-elb-https"
+    internal = "${var.internal_elb}"
+
+    listener {
+        instance_port      = 8080
+        instance_protocol  = "tcp"
+        lb_port            = 443
+        lb_protocol        = "ssl"
+        ssl_certificate_id = "${aws_iam_server_certificate.rancher_ha.arn}"
+    }
+
+    health_check {
+        healthy_threshold   = 2
+        unhealthy_threshold = 2
+        timeout             = 3
+        target              = "HTTP:8080/ping"
+        interval            = 30
+    }
+
+    subnets         = ["${aws_subnet.rancher_ha.*.id}"]
+    security_groups = ["${aws_security_group.rancher_ha_elb.id}"]
+    instances       = ["${aws_instance.rancher_ha.*.id}"]
+
+    idle_timeout                = 400
+    cross_zone_load_balancing   = true
+    connection_draining         = true
+    connection_draining_timeout = 400
+
+    tags {
+        Name = "${var.name_prefix}-elb-https"
+    }
+}
+
+resource "aws_iam_server_certificate" "rancher_ha" {
+    count             = "${var.enable_https}"
+    name              = "${var.name_prefix}-certificate"
+    certificate_body  = "${file("${var.cert_body}")}"
+    private_key       = "${file("${var.cert_private_key}")}"
+    certificate_chain = "${file("${var.cert_chain}")}"
+}
+
+resource "aws_proxy_protocol_policy" "rancher_ha_https_proxy_policy" {
+    count          = "${var.enable_https}"
+    load_balancer  = "${aws_elb.rancher_ha_https.name}"
+    instance_ports = ["81", "443", "8080"]
+}
+
+resource "aws_security_group_rule" "allow_https" {
+    count             = "${var.enable_https}"
+    type              = "ingress"
+    from_port         = 443
+    to_port           = 443
+    protocol          = "tcp"
+    cidr_blocks       = ["0.0.0.0/0"]
+    security_group_id = "${aws_security_group.rancher_ha_elb.id}"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,12 @@
+#------------------------------------------#
+# AWS Outputs
+#------------------------------------------#
+output "elb_http_dns" {
+    #value = "${aws_elb.rancher_ha_http.dns_name}"
+    value = "${aws_elb.rancher_ha_http.dns_name}"
+}
+
+#output "elb_https_dns" {
+#    #value = "${aws_elb.rancher_ha_https.dns_name}"
+#    value = "${aws_elb.rancher_ha_https.dns_name}"
+#}

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,13 @@
+# AWS key for the instances
+key_name = "amaris"
+aws_access_key = "AKIAJU7CIPB7TUHKCELA"
+aws_secret_key = "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"
+
+# RDS database password
+db_pass = "rancherdbpass"
+
+# To enable SSL termination on the ELBs, uncomment the lines below.
+# enable_https = true
+# cert_body = "certs/cert1.pem"              # Signed Certificate
+# cert_private_key = "certs/privkey1.pem"    # Certificate Private Key
+# cert_chain = "certs/chain1.pem"            # CA chain

--- a/terraform.tfvars.sample
+++ b/terraform.tfvars.sample
@@ -1,0 +1,13 @@
+# AWS key for the instances
+key_name = "keyname"
+aws_access_key = "aws-access-key"
+aws_secret_key = "aws-secret-key"
+
+# RDS database password
+db_pass = "rancherdbpass"
+
+# To enable SSL termination on the ELBs, uncomment the lines below.
+# enable_https = true
+# cert_body = "certs/cert1.pem"              # Signed Certificate
+# cert_private_key = "certs/privkey1.pem"    # Certificate Private Key
+# cert_chain = "certs/chain1.pem"            # CA chain

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,142 @@
+#------------------------------------------#
+# General Variables
+#------------------------------------------#
+variable "ssh_user" {
+  default = "ubuntu"
+}
+variable "public_key_path" {
+  default = "~/.ssh/id_rsa.pub"
+}
+variable "private_key_path" {
+  default = "~/.ssh/id_rsa"
+}
+
+#------------------------------------------#
+# AWS Environment Variables
+#------------------------------------------#
+variable "region" {
+    default     = "eu-central-1"
+    description = "The region of AWS, for AMI lookups"
+}
+
+variable "count_srv" {
+    default     = "1"
+    description = "Number of HA servers to deploy"
+}
+
+variable "count_host_dev_env" {
+    default     = "1"
+    description = "Number of HA dev env host to deploy"
+}
+
+variable "name_prefix" {
+    default     = "rancher-ha"
+    description = "Prefix for all AWS resource names"
+}
+
+variable "name_prefix_host_dev" {
+    default     = "rancher-dev"
+    description = "Prefix for all AWS resource names"
+}
+
+variable "ami" {
+    default     = "ami-6dec0c02"
+    description = "Instance AMI ID ubuntu-14.04-docker-1.10.3.0"
+}
+
+variable "key_name" {
+    description = "SSH key name in your AWS account for AWS instances"
+}
+
+variable "aws_access_key" {
+    description = "AWS Access Key"
+}
+
+variable "aws_secret_key" {
+    description = "AWS secret Key"
+}
+
+variable "instance_type" {
+    default     = "t2.large" # RAM Requirements >= 8gb
+    description = "AWS Instance type"
+}
+
+variable "root_volume_size" {
+    default     = "16"
+    description = "Size in GB of the root volume for instances"
+}
+
+variable "vpc_cidr" {
+    default     = "192.168.199.0/24"
+    description = "Subnet in CIDR format to assign to VPC"
+}
+
+variable "subnet_cidrs" {
+    default     = ["192.168.199.0/26", "192.168.199.64/26", "192.168.199.128/26"]
+    description = "Subnet ranges (requires 3 entries)"
+}
+
+variable "availability_zones" {
+    default     = ["eu-central-1a", "eu-central-1b", "eu-central-1c"]
+    description = "Availability zones to place subnets"
+}
+
+variable "internal_elb" {
+    default     = "false"
+    description = "Force the ELB to be internal only"
+}
+
+#------------------------------------------#
+# Database Variables
+#------------------------------------------#
+variable "db_name" {
+    default     = "rancher"
+    description = "Name of the RDS DB"
+}
+
+variable "db_user" {
+    default     = "rancher"
+    description = "Username used to connect to the RDS database"
+}
+
+variable "db_pass" {
+    description = "Password used to connect to the RDS database"
+}
+
+#------------------------------------------#
+# SSL Variables
+#------------------------------------------#
+variable "enable_https" {
+    default     = false
+    description = "Enable HTTPS termination on the loadbalancer"
+}
+
+variable "cert_body" {
+    default = ""
+}
+
+variable "cert_private_key" {
+    default = ""
+}
+
+variable "cert_chain" {
+    default = ""
+}
+
+#------------------------------------------#
+# Rancher Variables
+#------------------------------------------#
+variable "rancher_version" {
+    default     = "stable"
+    description = "Rancher version to deploy"
+}
+
+variable "rancher_access_key" {
+    default = "F06A40A3C9A81EC3C07B"
+    description = "Rancher Env Access Key"
+}
+
+variable "rancher_secret_key" {
+    default = "BuPfyGcnm5oVrwhbJhkmbDoGQESoKiBZK2Seu1ZA"
+    description = "Rancher Env Secret Key"
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,47 @@
+#------------------------------------------#
+# AWS VPC Configuration
+#------------------------------------------#
+resource "aws_vpc" "rancher_ha" {
+    cidr_block           = "${var.vpc_cidr}"
+    enable_dns_support   = true
+    enable_dns_hostnames = true
+    tags {
+        Name = "${var.name_prefix}-vpc"
+    }
+}
+
+resource "aws_subnet" "rancher_ha" {
+    count                   = "3"
+    vpc_id                  = "${aws_vpc.rancher_ha.id}"
+    cidr_block              = "${element(var.subnet_cidrs, count.index)}"
+    availability_zone       = "${element(var.availability_zones, count.index)}"
+    map_public_ip_on_launch = true
+    tags {
+      Name = "${var.name_prefix}-subnet-${count.index}"
+    }
+}
+
+resource "aws_internet_gateway" "rancher_ha" {
+    vpc_id     = "${aws_vpc.rancher_ha.id}"
+    depends_on = ["aws_vpc.rancher_ha"]
+    tags {
+      Name = "${var.name_prefix}-igw"
+    }
+}
+
+resource "aws_route" "rancher_ha" {
+    route_table_id         = "${aws_vpc.rancher_ha.main_route_table_id}"
+    destination_cidr_block = "0.0.0.0/0"
+    gateway_id             = "${aws_internet_gateway.rancher_ha.id}"
+    depends_on             = ["aws_vpc.rancher_ha", "aws_internet_gateway.rancher_ha"]
+}
+
+resource "aws_vpc_dhcp_options" "rancher_dns" {
+    domain_name         = "ec2.internal"
+    domain_name_servers = ["169.254.169.253", "AmazonProvidedDNS"]
+}
+
+resource "aws_vpc_dhcp_options_association" "rancher_dns" {
+    vpc_id          = "${aws_vpc.rancher_ha.id}"
+    dhcp_options_id = "${aws_vpc_dhcp_options.rancher_dns.id}"
+}


### PR DESCRIPTION
This mix of tools will deploy a HA rancher server and environment nodes into AWS using Terraform to deploy infrastructure and Ansible playbook from the original repo AdopteUnOps.

Usage:

Edit the terraform.tfvars file:

# AWS key for the instances
key_name = "rancher-example"

# RDS database password
db_pass = "rancherdbpass"

# To enable SSL termination on the ELBs, uncomment the lines below.
#enable_https = true
#cert_body = "certs/cert1.pem"              # Signed Certificate
#cert_private_key = "certs/privkey1.pem"    # Certificate Private Key
#cert_chain = "certs/chain1.pem"            # CA chain

To create the cluster:

terraform apply

To destroy:

terraform destroy

Variables
AWS Infrastructure

    region: AWS region (default: us-east-1)
    count: number of HA servers to deploy (default: 3)
    name_prefix: prefix for all AWS resource names (default: rancher-ha)
    ami: instance AMI ID (default: ami-dfdff3c8; RancherOS in us-east-1)
    key_name: SSH key name in your AWS account for AWS instances (required)
    instance_type: AWS instance type (default: t2.large for RAM requirement)
    root_volume_size: size in GB of the instance root volume (default: 16)
    vpc_cidr: subnet in CIDR format to assign to the VPC (default: 192.168.199.0/24)
    subnet_cidrs: list of subnet ranges (3 required) (default: ["192.168.199.0/26", "192.168.199.64/26", "192.168.199.128/26")
    availability_zones: AZs for placing instances and subnets (may change based on your account's availability) (default: ["us-east-1a", "us-east-1b", "us-east-1d"])
    internal_elb: Make ELB internal to VPC vs externally accessible (default: false)

    Note: if you use an AMI other than RancherOS, the automatic launching of the Rancher server container will not work. You will need to update the user-data template according to the needs of your AMI.

Database

    db_name: name of the RDS DB (default: rancher)
    db_user: username used to connect to the RDS database (default: rancher)
    db_pass: password used to connect to the RDS database (required)

SSL

    enable_https: enable HTTPS termination on the loadbalancer (default: false)
    cert_body: required if enable_https is set to true
    cert_private_key: required if enable_https is set to true
    cert_chain: required if enable_https is set to true

Rancher

    rancher_version: Rancher version to deploy (default: stable)
